### PR TITLE
Enable image analysis for Ollama backend

### DIFF
--- a/llm_handler/__init___.py
+++ b/llm_handler/__init___.py
@@ -6,6 +6,6 @@ def query_llm(backend="claude", image_path=None, metadata=""):
     if backend == "claude":
         return send_to_claude(image_path, metadata)
     elif backend == "ollama":
-        return send_to_ollama(metadata)
+        return send_to_ollama(metadata=metadata, image_path=image_path)
     else:
         return "Invalid backend selected."

--- a/llm_handler/ollama.py
+++ b/llm_handler/ollama.py
@@ -1,12 +1,34 @@
 import requests
+from .base import encode_image_base64
+
+# Note for Image Analysis with Ollama:
+# To use image analysis features, ensure you have a multimodal model
+# (e.g., "llava:latest") downloaded and running via Ollama.
+# If you are using a different multimodal model, you may need to update
+# the `model_name` variable within the `send_to_ollama` function below.
 
 
-def send_to_ollama(metadata):
-    prompt = f"Analyze this Blender scene:\n\n{metadata}"
+def send_to_ollama(metadata, image_path=None):
+    model_name = "llava:latest"  # Common multimodal model
+
+    if image_path:
+        base64_image = encode_image_base64(image_path)
+        prompt = f"Analyze this image and its Blender scene metadata:\n\n{metadata}"
+        payload = {
+            "model": model_name,
+            "prompt": prompt,
+            "images": [base64_image],
+        }
+    else:
+        prompt = f"Analyze this Blender scene metadata:\n\n{metadata}"
+        payload = {
+            "model": model_name,
+            "prompt": prompt,
+        }
 
     response = requests.post(
         "http://localhost:11434/api/generate",
-        json={"model": "gemma3:4b", "prompt": prompt},  # or any model you have loaded
+        json=payload,
     )
 
     return response.json()["response"]


### PR DESCRIPTION
This change enhances the Blender MCP addon to support image-based analysis when Ollama is selected as the LLM backend.

Key changes:
- Modified `llm_handler/ollama.py` to accept an image path, encode the image to base64, and send it to a multimodal Ollama model (defaults to `llava:latest`).
- Updated `llm_handler/__init___.py` to correctly pass the image path to the Ollama handler.
- Added a comment in `llm_handler/ollama.py` to guide you on the requirement for a multimodal Ollama model for this feature to work.

This allows the "Ask LLM About Scene" operator in Blender to send both the scene screenshot and textual summary to Ollama, providing more context to the LLM.