### PR TITLE
Fix: Change relative import to direct import for addon_utils

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -47,7 +47,7 @@ import mathutils
 from bpy.props import StringProperty, IntProperty, BoolProperty, EnumProperty
 
 # Local imports
-from . import addon_utils # For our utility functions
+import addon_utils # For our utility functions
 # Ensure llm_handler is imported if MCP_OT_AskLLMAboutScene uses it directly
 # For now, assuming it's imported within the execute method as per previous structure.
 


### PR DESCRIPTION
Changed `from . import addon_utils` to `import addon_utils` in `addon.py` to resolve an `ImportError: attempted relative import with no known parent package`. This occurs when Blender doesn't treat the addon's directory as a formal package for relative dot imports. Direct import is a common workaround for multi-file addons structured this way.