### PR TITLE
Fix: Change relative import to direct for llm_handler in operator

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -411,7 +411,7 @@ class MCP_OT_AskLLMAboutScene(bpy.types.Operator):
     def execute(self, context):
         # Ensure llm_handler is imported correctly, typically done at module level
         # but can be function-local if it causes issues during registration
-        from .llm_handler import query_llm
+        from llm_handler import query_llm
 
         image_path = render_and_save_image()
         metadata = extract_scene_summary()


### PR DESCRIPTION
Changed `from .llm_handler import query_llm` to `from llm_handler import query_llm` within the `MCP_OT_AskLLMAboutScene` operator in `addon.py`.

This resolves an `ImportError: attempted relative import with no known parent package` that occurred when the operator was executed. This change mirrors the previous fix for importing `addon_utils` and ensures that Blender can correctly locate the `llm_handler` package.